### PR TITLE
GTM - remove github-pages specific check.

### DIFF
--- a/_includes/page-head.html
+++ b/_includes/page-head.html
@@ -18,7 +18,7 @@
   <!-- Custom styles for this template -->
   <link href="css/landing-page.css" rel="stylesheet">
 
-  {% if site.google_tag_manager and jekyll.environment == 'production' %}
+  {% if site.google_tag_manager and jekyll.environment != 'test' %}
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -59,7 +59,7 @@
 
 <body>
 
-    {% if site.google_tag_manager and jekyll.environment == 'production' %}
+    {% if site.google_tag_manager and jekyll.environment != 'test' %}
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{site.google_tag_manager}}"
       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/_includes/slides-head.html
+++ b/_includes/slides-head.html
@@ -12,7 +12,7 @@
 		<!-- Theme used for syntax highlighting of code -->
 		<!-- link rel="stylesheet" href="lib/css/zenburn.css"-->
 
-		{% if site.google_tag_manager and jekyll.environment == 'production' %}
+		{% if site.google_tag_manager and jekyll.environment != 'test' %}
 		<!-- Google Tag Manager -->
 		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -33,7 +33,7 @@
 		
 	</head>
 	<body>
-		{% if site.google_tag_manager and jekyll.environment == 'production' %}
+		{% if site.google_tag_manager and jekyll.environment != 'test' %}
 
 		<!-- Google Tag Manager (noscript) -->
 		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{site.google_tag_manager}}"


### PR DESCRIPTION
Before serving the GTM code, we used to check are the pages served by GitHub pages (to not let local tests to skew the stats). The pages are not anymore in GitHub pages, so the check is invalid.